### PR TITLE
fix: 한 사용자만 매칭 수락 시 임시 세션 아이디가 반환되는 문제 해결

### DIFF
--- a/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
@@ -90,7 +90,7 @@ public class MatchController {
             messagingTemplate.convertAndSendToUser(opponentMatchRequest.getUsername(), DESTINATION_URL, new GenericMessage<>(matchResponseDTO, headers));
         } else {
             messagingTemplate.convertAndSendToUser(matchRequest.getUsername(), DESTINATION_URL, new GenericMessage<>(matchResponseDTO, headers));
-            messagingTemplate.convertAndSendToUser(opponentMatchRequest.getUsername(), DESTINATION_URL, new GenericMessage<>(new MatchResponseDTO(MatchDecisionStatus.ACCEPTED, matchRequest.getTempSessionId()), headers));
+            messagingTemplate.convertAndSendToUser(opponentMatchRequest.getUsername(), DESTINATION_URL, new GenericMessage<>(new MatchResponseDTO(MatchDecisionStatus.ACCEPTED, ""), headers));
         }
     }
 

--- a/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchServiceImpl.java
@@ -146,7 +146,7 @@ public class MatchServiceImpl implements MatchService {
             return handleAcceptedMatchedRequests(opponentMatchRequest.getTempSessionId());
         }
 
-        return new MatchResponseDTO(MatchDecisionStatus.WAITING, matchRequest.getTempSessionId());
+        return new MatchResponseDTO(MatchDecisionStatus.WAITING, "");
     }
 
     @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
 
- [ ] 기능 삭제

- [X] 버그 수정

- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop -> main

### 변경 사항 
- 한 사용자만 매칭 수락 시 임시 세션 아이디가 반환되는 문제 해결
