### PR TITLE
fix: 웹소켓 연결 종료 시 매칭 대기열이 업데이트 되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/controller/MatchController.java
@@ -117,6 +117,9 @@ public class MatchController {
     // WebSocket 연결 해제 처리
     @EventListener
     public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        Optional.ofNullable(event.getUser())
+                        .ifPresent(principal -> matchService.cancelSearchingByUsername(principal.getName()));
+
         Optional.ofNullable(SimpMessageHeaderAccessor.wrap(event.getMessage()).getSessionAttributes())
                 .map(headers -> (String) headers.get(MATCH_REQUEST_ID))
                 .ifPresent(matchService::removeRideRequest);

--- a/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchServiceImpl.java
+++ b/src/main/java/com/dnlab/tacktogetherbackend/match/service/MatchServiceImpl.java
@@ -170,12 +170,12 @@ public class MatchServiceImpl implements MatchService {
 
     @Override
     public void cancelSearchingByUsername(String username) {
-        log.debug("removeMatchRequestsByUsername 이 username{" + username + "} 에 의해 호출됨");
         activeMatchRequests.keySet()
                 .stream()
-                .map(activeMatchRequests::get)
-                .filter(matchRequest -> matchRequest.getUsername().equals(username))
-                .forEach(matchRequest -> activeMatchRequests.remove(matchRequest.getId()));
+                .filter(key -> key.startsWith(username))
+                .forEach(activeMatchRequests::remove);
+
+        log.info("삭제 후 매칭 대기열 : " + activeMatchRequests);
     }
 
     private boolean isSuitableOriginRanges(MatchRequest req1, MatchRequest req2) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
 
- [ ] 기능 삭제

- [X] 버그 수정

- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop -> main

### 변경 사항 
- 웹소켓 연결 종료 시 매칭 대기열이 업데이트 되지 않는 문제 해결
